### PR TITLE
[버그수정] 라이브러리 이름 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "hookform/resolvers": "^3.7.0",
+    "@hookform/resolvers": "^3.7.0",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",


### PR DESCRIPTION

![image](https://github.com/codeit-part4-project/Mogazoa/assets/159979425/2c17d95f-1bb2-4516-84d4-f818bd38f9ce)


이름 맨앞에 @가 없으면 이름에 /가 있는 라이브러리 이름을 사용할 수 없다고 합니다.

dev 브랜치에 현재 이렇게 들어가있어서 npm i 하면서
Invalid package name "hookform/resolvers" of package "hookform/resolvers@^3.7.0": name can only contain URL-friendly characters. 라는 오류가 생겨 기존 코드로 원상복구 했습니다.