### PR TITLE
[디자인] Gnb 바 추가

### DIFF
--- a/app/_styled-guide/_components/gnb.tsx
+++ b/app/_styled-guide/_components/gnb.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+import { Button, buttonVariants } from '@/components/ui/button';
+import Link from 'next/link';
+import Logo from './logo';
+import { FiMenu } from 'react-icons/fi';
+import { IoSearch } from 'react-icons/io5';
+
+interface GnbProps {
+  isLogin?: boolean;
+}
+
+function Gnb({ isLogin = false }: GnbProps) {
+  // const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false); : 모바일 검색버튼 열림 상태
+
+  return (
+    <div className="mb-[70px] md:mb-20 lg:mb-[100px]">
+      {/* 태블릿 이상일 시 디자인 */}
+      <div className="hidden md:block">
+        <div className="flex justify-between items-center w-full md:h-20 lg:h-[100px] md:px-[30px] lg:px-[120px] fixed inset-x-0 top-0 bg-black-600">
+          <Logo />
+          <div className="flex justify-between md:gap-[30px] lg:gap-[60px]">
+            {/* 임시용, search-bar 컴포넌트로 대체 예정 */}
+            <div className="text-white text-nowrap">search bar</div>
+            {isLogin && (
+              <>
+                <Link href="/compare" className={buttonVariants({ variant: 'text', size: 'auto' })}>
+                  비교하기
+                </Link>
+                <Link href="/mypage" className={buttonVariants({ variant: 'text', size: 'auto' })}>
+                  내 프로필
+                </Link>
+              </>
+            )}
+            {!isLogin && (
+              <>
+                <Link href="/signin" className={buttonVariants({ variant: 'text', size: 'auto' })}>
+                  로그인
+                </Link>
+                <Link href="/signup" className={buttonVariants({ variant: 'text', size: 'auto' })}>
+                  회원가입
+                </Link>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* 모바일 디자인 */}
+      <div className="block md:hidden">
+        <div className="flex justify-between items-center w-full h-[70px] px-5 fixed inset-x-0 top-0 bg-black-600">
+          {/* 임시용 버튼 */}
+          <button>
+            <FiMenu className="text-gray-500 h-6 w-6" />
+          </button>
+          <Logo />
+          {/* 임시용 버튼 */}
+          <button>
+            <IoSearch className="text-gray-500 h-6 w-6" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default Gnb;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/318ec12b-4724-4813-8e84-5b4d6005abf6)
![image](https://github.com/user-attachments/assets/a7c72381-f42a-4ba9-b012-44bb88c83f9a)
![image](https://github.com/user-attachments/assets/22740557-43e0-42e8-880b-bfc491971f0e)

- Gnb
```
<Gnb isLogin={true} />
<Gnb />   
```

현재 검색 관련 기능은 안들어가있고, 디자인만 되어있습니다. 
검색을 제외한 나머지 버튼의 링크는 사용 가능합니다.

모바일 디자인이 크게 다른건 tailwind의 반응형 값을 이용해서 hidden옵션을 주는 방식으로 나눠서 개발했는데 성능적으로 어떨지 잘 모르겠습니다. 개발자도구로 보니까 두 hidden인 div도 요소에서 확인이 되더라고요... 문제가 되면 화면 너비를 ref훅으로 가져와서 조건부 렌더링 하는 쪽으로 변경하겠습니다.
