### PR TITLE
[모달경고수정] 모달 ui shadcn의 description 사용하지 않을 경고 수정

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import QueryProviderWrapper from '@/components/QueryProviderWrapper';
+import { Toaster } from 'sonner';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -19,6 +20,7 @@ export default function RootLayout({
     <html lang="ko">
       <body className={inter.className}>
         <QueryProviderWrapper>{children}</QueryProviderWrapper>
+        <Toaster position="top-center" />
       </body>
     </html>
   );

--- a/components/modal/compare.tsx
+++ b/components/modal/compare.tsx
@@ -3,6 +3,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -17,6 +18,7 @@ export default function Compare() {
         <Button>비교모달</Button>
       </DialogTrigger>
       <DialogContent className="max-w-[540px]">
+        <DialogDescription className="hidden">compare content</DialogDescription>
         <DialogHeader>
           <DialogTitle>지금 보신 ‘Sony WH-1300XM3’ 어떤 상품과 비교할까요?</DialogTitle>
         </DialogHeader>

--- a/components/modal/confirm.tsx
+++ b/components/modal/confirm.tsx
@@ -3,6 +3,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -18,6 +19,7 @@ export default function Confirm() {
         <Button>비교상품교체모달확인 바로가기</Button>
       </DialogTrigger>
       <DialogContent className="max-w-[540px]">
+        <DialogDescription className="hidden">confirm content</DialogDescription>
         <DialogHeader>
           <DialogTitle>
             비교 상품이 교체되었습니다.

--- a/components/modal/product.tsx
+++ b/components/modal/product.tsx
@@ -139,9 +139,9 @@ export default function Product() {
                       className="h-[120px] smd:h-[160px]"
                     />
                   </FormControl>
-                  <FormDescription className="absolute bottom-5 right-5 text-sm text-gray-600">
-                    2/30
-                  </FormDescription>
+                  <span className="absolute bottom-5 right-5 text-sm text-gray-600 px-1 bg-black-450">
+                    2/300
+                  </span>
                   <FormMessage />
                 </FormItem>
               )}

--- a/components/modal/product.tsx
+++ b/components/modal/product.tsx
@@ -4,6 +4,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -48,6 +49,7 @@ export default function Product() {
         <Button>상품 모달</Button>
       </DialogTrigger>
       <DialogContent className="max-w-[660px]">
+        <DialogDescription className="hidden">product form content</DialogDescription>
         <DialogHeader>
           <DialogTitle className="flex flex-col gap-5 md:gap-[10px]">상품 편집</DialogTitle>
         </DialogHeader>
@@ -148,7 +150,7 @@ export default function Product() {
         </Form>
         <DialogFooter className="sm:justify-start">
           <DialogClose asChild>
-            <Button type="button" variant="default">
+            <Button type="button" variant="default" onClick={form.handleSubmit(onSubmit)}>
               저장하기
             </Button>
           </DialogClose>

--- a/components/modal/profile.tsx
+++ b/components/modal/profile.tsx
@@ -4,6 +4,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -46,14 +47,12 @@ export default function Profile() {
         <Button>프로필 모달</Button>
       </DialogTrigger>
       <DialogContent className="max-w-[660px]">
+        <DialogDescription className="hidden">profile form content</DialogDescription>
         <DialogHeader>
           <DialogTitle className="flex flex-col gap-5 md:gap-[10px]">프로필 편집</DialogTitle>
         </DialogHeader>
         <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit(onSubmit)}
-            className="w-full space-y-[10px] md:space-y-4 lg:space-y-5"
-          >
+          <form onSubmit={form.handleSubmit(onSubmit)} className="w-full md:space-y-4 lg:space-y-5">
             {/* 이미지 추가 */}
             <FormField
               control={form.control}
@@ -69,12 +68,11 @@ export default function Profile() {
                           htmlFor="profilePicture"
                           variant="file"
                           style={{
-                            backgroundImage:
-                              "url('https://search.pstatic.net/common/?src=http%3A%2F%2Fblogfiles.naver.net%2F20160406_70%2Fjane0014_145991895474804Yrl_PNG%2F20160324_1822371.png&type=sc960_832')",
+                            backgroundImage: "url('')",
                           }}
                         >
                           {/* 삭제버튼 */}
-                          {true ? (
+                          {false ? (
                             <Button
                               asChild
                               variant="iconBg"
@@ -130,7 +128,7 @@ export default function Profile() {
         </Form>
         <DialogFooter className="sm:justify-start">
           <DialogClose asChild>
-            <Button type="button" variant="default">
+            <Button type="button" variant="default" onClick={form.handleSubmit(onSubmit)}>
               저장하기
             </Button>
           </DialogClose>

--- a/components/modal/profile.tsx
+++ b/components/modal/profile.tsx
@@ -117,9 +117,9 @@ export default function Profile() {
                       className="h-[120px] smd:h-[160px]"
                     />
                   </FormControl>
-                  <FormDescription className="absolute bottom-5 right-5 text-sm text-gray-600">
-                    2/30
-                  </FormDescription>
+                  <span className="absolute bottom-5 right-5 text-sm text-gray-600 px-1 bg-black-450">
+                    2/300
+                  </span>
                   <FormMessage />
                 </FormItem>
               )}

--- a/components/modal/review.tsx
+++ b/components/modal/review.tsx
@@ -4,6 +4,7 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -58,7 +59,8 @@ export default function Review() {
       <DialogTrigger asChild>
         <Button>리뷰모달</Button>
       </DialogTrigger>
-      <DialogContent className="max-w-[660px]">
+      <DialogContent className="max-w-[660px]" aria-describedby="dialog-review">
+        <DialogDescription className="hidden">review form content</DialogDescription>
         <DialogHeader>
           <DialogTitle className="flex flex-col gap-[10px]">
             <CategoryTag categoryName="전자기기" categoryId={6} />
@@ -98,14 +100,11 @@ export default function Review() {
               control={form.control}
               name="review"
               render={({ field }) => (
-                <FormItem>
+                <FormItem className="relative">
                   <FormControl>
-                    <Textarea
-                      placeholder="리뷰를 작성해 주세요"
-                      className="resize-none"
-                      {...field}
-                    />
+                    <Textarea placeholder="리뷰를 작성해 주세요" />
                   </FormControl>
+                  <span className="absolute bottom-5 right-5 text-sm text-gray-600">2/30</span>
                   <FormMessage />
                 </FormItem>
               )}
@@ -156,7 +155,7 @@ export default function Review() {
         </Form>
         <DialogFooter className="sm:justify-start">
           <DialogClose asChild>
-            <Button type="button" variant="default">
+            <Button type="button" variant="default" onClick={form.handleSubmit(onSubmit)}>
               작성하기
             </Button>
           </DialogClose>

--- a/components/modal/review.tsx
+++ b/components/modal/review.tsx
@@ -104,7 +104,9 @@ export default function Review() {
                   <FormControl>
                     <Textarea placeholder="리뷰를 작성해 주세요" />
                   </FormControl>
-                  <span className="absolute bottom-5 right-5 text-sm text-gray-600">2/30</span>
+                  <span className="absolute bottom-5 right-5 text-sm text-gray-600 px-1 bg-black-450">
+                    2/300
+                  </span>
                   <FormMessage />
                 </FormItem>
               )}


### PR DESCRIPTION
- 모달의 DialogDescription을 사용하지 않아 경고가 뜨는 부분 수정
![image](https://github.com/user-attachments/assets/72069390-04a3-42f9-b3cb-71008c586f4a)

- toast 전역에서 사용하기 위해 app/layout에 토스트 연결

- text 글자가 많아 지면, 글자수 부분의 글자 겹침으로 bg넣어서 분리
(이 부분은 디자인이 없어서 우선 임시로 배경을 넣었습니다., 추 후 더 좋은 디자인이 보이면 수정  할 수 있습니다.)
![image](https://github.com/user-attachments/assets/853f63f4-a0b0-4746-a855-2d7b31ee9fd6)
