### PR TITLE
[기능추가] gnb 검색 기능 추가, 관련 hook 추가

### DIFF
--- a/app/_styled-guide/_components/DropdownList.tsx
+++ b/app/_styled-guide/_components/DropdownList.tsx
@@ -1,9 +1,10 @@
 'use client';
 
+import { NO_KEYWORD, NO_RESULT } from '@/constants/messages';
+
 interface DropdownListProps {
   options: string[];
   onSelect: (option: string) => void;
-  onClose: () => void;
   className?: string;
   optionClassName?: string;
 }
@@ -13,22 +14,27 @@ interface DropdownListProps {
 const DropdownList: React.FC<DropdownListProps> = ({
   options,
   onSelect,
-  onClose,
   className,
   optionClassName,
 }) => {
+  // options이나 placeholder가 없을 경우 컴포넌트가 나타나지 않습니다.
+  if (options.length === 0) return;
+
+  // 검색 결과가 없을 경우 버튼 비활성화
+  const isDisabled = options[0] === NO_RESULT || options[0] === NO_KEYWORD;
+
   return (
     <ul
-      className={`flex flex-col z-10 gap-[5px] p-2.5 rounded-lg absolute mt-2 w-full border-gray-700 bg-black-450 text-gray-600 shadow-lg ${className}`}
+      className={`flex flex-col z-10 gap-[5px] p-2.5 rounded-lg absolute mt-2 w-full border-gray-700 bg-black-450 text-gray-600 shadow-lg ${className} `}
     >
       {options.map((option) => (
         <li key={option}>
           <button
             onClick={() => {
               onSelect(option);
-              onClose();
             }}
             className={`w-full px-5 py-[6px] text-left truncate rounded-md hover:bg-gray-700 focus:bg-gray-700 hover:text-white focus:text-white ${optionClassName}`}
+            disabled={isDisabled}
           >
             {option}
           </button>

--- a/app/_styled-guide/_components/gnb-search-bar.tsx
+++ b/app/_styled-guide/_components/gnb-search-bar.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { IoSearch } from 'react-icons/io5';
+import React, { useState, useRef } from 'react';
+import useSearchSuggestions from '@/hooks/useSearchSuggestions';
+import DropdownList from './DropdownList';
+import { useRouter } from 'next/navigation';
+
+interface SearchBarProps {
+  placeholder?: string;
+}
+
+// Gnb에서 사용하기 위해서 만들어진 검색창입니다.
+const GnbSearchBar = ({ placeholder = '상품 이름을 검색해 보세요' }: SearchBarProps) => {
+  const [keyword, setKeyword] = useState('');
+  const { suggestions, isLoading, isError } = useSearchSuggestions(keyword);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const router = useRouter();
+
+  // 검색창 input 활성화시, dropdownList 열림
+  const handleFocus = () => {
+    setIsDropdownOpen(true);
+  };
+
+  const handleBlur = () => {
+    // input 요소가 focus를 잃어도 0.2초동안 Dropdown을 유지합니다.
+    setTimeout(() => {
+      if (!inputRef.current?.contains(document.activeElement)) {
+        setIsDropdownOpen(false);
+      }
+    }, 200);
+  };
+
+  // 검색 처리 함수. 한 글자 이상 입력해야 함
+  const executeSearch = () => {
+    if (keyword.trim()) {
+      router.push(`/search?q=${keyword}`);
+    }
+  };
+
+  // 검색창에서 Enter 키 입력 처리
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      executeSearch();
+    }
+  };
+
+  // dropdownList에서 option 선택 시 콜백
+  const onSelect = (value: string) => {
+    setKeyword(value);
+    inputRef.current?.focus();
+  };
+
+  return (
+    <div className="relative">
+      <div className="flex justify-between items-center md:w-[300px] lg:w-[400px] md:h-[50px] lg:h-14 py-4 px-5 bg-black-450 rounded-full">
+        <IoSearch
+          className="md:mr-[10px] lg:mr-5 h-6 w-6 text-gray-400 cursor-pointer"
+          onClick={executeSearch}
+        />
+        <input
+          ref={inputRef}
+          type="text"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="w-full bg-transparent focus:outline-none text-white"
+        />
+      </div>
+      {isDropdownOpen && <DropdownList options={suggestions} onSelect={onSelect} />}
+    </div>
+  );
+};
+
+export default GnbSearchBar;

--- a/app/_styled-guide/_components/gnb.tsx
+++ b/app/_styled-guide/_components/gnb.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import Logo from './logo';
 import { FiMenu } from 'react-icons/fi';
 import { IoSearch } from 'react-icons/io5';
-
+import GnbSearchBar from './gnb-search-bar';
 interface GnbProps {
   isLogin?: boolean;
 }
@@ -21,8 +21,7 @@ function Gnb({ isLogin = false }: GnbProps) {
         <div className="flex justify-between items-center w-full md:h-20 lg:h-[100px] md:px-[30px] lg:px-[120px] fixed inset-x-0 top-0 bg-black-600">
           <Logo />
           <div className="flex justify-between md:gap-[30px] lg:gap-[60px]">
-            {/* 임시용, search-bar 컴포넌트로 대체 예정 */}
-            <div className="text-white text-nowrap">search bar</div>
+            <GnbSearchBar />
             {isLogin && (
               <>
                 <Link href="/compare" className={buttonVariants({ variant: 'text', size: 'auto' })}>

--- a/constants/messages.ts
+++ b/constants/messages.ts
@@ -1,0 +1,2 @@
+export const NO_RESULT: string = '검색 결과가 없습니다.';
+export const NO_KEYWORD: string = '검색어를 입력해주세요';

--- a/hooks/useDebounce.ts
+++ b/hooks/useDebounce.ts
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+// Debounce 훅
+// value가 들어오면 delay만큼 지난 뒤에 변경해 리턴합니다.
+const useDebounce = (value: string, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/hooks/useSearchSuggestions.ts
+++ b/hooks/useSearchSuggestions.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react';
+import useDebounce from './useDebounce';
+import { useDataQuery } from '@/services/common';
+import { ProductsListResponse } from '@/types/data';
+import { NO_KEYWORD, NO_RESULT } from '@/constants/messages';
+
+interface UseSearchSuggestionsOptions {
+  maxSuggestions?: number;
+  previousSearch?: string[];
+}
+
+const useSearchSuggestions = (
+  keyword: string,
+  { maxSuggestions, previousSearch = [] }: UseSearchSuggestionsOptions = {},
+) => {
+  const debouncedKeyword = useDebounce(keyword, 300);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [previousSuggestions, setPreviousSuggestions] = useState<string[]>(previousSearch);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
+
+  const {
+    data,
+    isLoading: queryLoading,
+    isError: queryError,
+  } = useDataQuery<undefined, ProductsListResponse>(
+    ['products', 'searchSuggestions', debouncedKeyword],
+    '/products',
+    undefined,
+    {
+      enabled: !!debouncedKeyword,
+      staleTime: 60 * 1000,
+    },
+    { keyword: debouncedKeyword },
+  );
+
+  useEffect(() => {
+    if (debouncedKeyword) {
+      setIsLoading(true);
+      setIsError(false);
+      if (!queryLoading && data) {
+        // 상품 목록 데이터에서 이름만 추출
+        const options = data.list.map((product) => product.name);
+
+        // 항목 최대 수
+        const limitedOptions = maxSuggestions ? options.slice(0, maxSuggestions) : options;
+
+        // 검색결과가 없으면 NO_RESULT를 보여줍니다.
+        setSuggestions(limitedOptions.length > 0 ? limitedOptions : [NO_RESULT]);
+        setIsLoading(false);
+      } else if (queryError) {
+        setSuggestions(['서버와의 통신이 불안정합니다']);
+        setIsError(true);
+        setIsLoading(false);
+      }
+    } else {
+      // 키워드가 비어이있을 경우 이전에 검색한 결과를 보여줍니다. 전역 상태로 가져올 예정입니다.
+      // 이전 검색 결과도 비어있을 경우 NO_KEYWORD를 보여줍니다.
+      setSuggestions(previousSuggestions.length > 0 ? previousSuggestions : [NO_KEYWORD]);
+      setIsLoading(false);
+      setIsError(false);
+    }
+  }, [debouncedKeyword, data, queryLoading, queryError, previousSuggestions, maxSuggestions]);
+
+  return {
+    suggestions: suggestions,
+    isLoading,
+    isError,
+  };
+};
+
+export default useSearchSuggestions;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/25a07564-cbcf-4816-be06-950a3fe1d0bf)
![image](https://github.com/user-attachments/assets/d7d3b3fd-b566-4705-98b1-45ad10e32291)

- useDebounce 
검색 시 타이핑 할 때 마다 state가 변경되면서 http 요청을 보내는 현상을 막기 위해서 추가했습니다.
`const debouncedKeyword = useDebounce(keyword, 300);`
위 처럼 사용하면 keyword가 변경되어도 0.3초 후에 debouncedKeyword가 변경되기 때문에 해당 값을 사용하면 불필요한 렌더링 및 요청을 막을 수 있습니다.

- useSearchSuggestions
```
  const [keyword, setKeyword] = useState('');
  const { suggestions, isLoading, isError } = useSearchSuggestions(keyword);
```
검색 중 추천 검색어를 가져오는 훅입니다. 필요해서 따로 개발했고, useDataQuery를 사용했습니다.
useDebounce 훅으로 0.3초 딜레이를 주었습니다. 
몇몇 예외상황에서 보여질 처리를 넣었습니다만 완벽하진 않을 것 같아 이후에 테스트 과정에서 발견되는 이슈 공유해주시면 수정하겠습니다.

- gnbSearchBar
gnb에서만 사용하기 위해서 디자인된 검색창입니다.
useSearchSuggestion의 결과값을 드롭다운으로 보여줍니다.
드롭다운은 input창이 focus되면 열리고, 관련 기능때문에 0.2초뒤에 닫히게 해놨는데 나중에 열리고 닫히는 애니메이션을 추가해서 덮을 예정입니다.

선택지 중 하나를 선택하면 입력한 내용이 바뀝니다.
엔터키 혹은 돋보기 버튼을 눌렀을 때 검색 페이지로 이동합니다. 해당 내용은 Notion 문서대로 기능하도록 한 부분입니다.

- DropdownList
DropdownList의 onClose prop은 제거했습니다. 사용하실 때 모달 열고 닫듯이 isDropdownOpen같은 state로 관리하는 것이 더 효율적인 듯 합니다.


검색 관련 기능이 들어가는 컴포넌트가 한 군데 더 있어서 재사용 하기 좋게 뺄 수 있을 것 같은데 해당 컴포넌트 개발 해보면서 리팩토링도 고려해보겠습니다.