### PR TITLE
[기능추가] Dropdown 관련 컴포넌트 추가, 수정

### DIFF
--- a/app/_styled-guide/_components/CategorySelector.tsx
+++ b/app/_styled-guide/_components/CategorySelector.tsx
@@ -5,14 +5,14 @@ import { IoMdArrowDropdown } from 'react-icons/io';
 import DropdownList from './DropdownList';
 
 interface CategorySelectorProps {
-  category?: string[];
+  options?: string[];
   placeHolder?: string;
 }
 
 // 카테고리 선택 기능을 위한 드롭다운 메뉴 컴포넌트입니다.
 // 기본값으로 10개의 카테고리를 선택할 수 있습니다.
 const CategorySelector = (props: CategorySelectorProps) => {
-  const options = [
+  const defaultCategory = [
     '음악',
     '영화/드라마',
     '강의/책',
@@ -24,13 +24,18 @@ const CategorySelector = (props: CategorySelectorProps) => {
     '의류/악세서리',
     '앱',
   ];
-  const { category = options, placeHolder = '카테고리 선택' } = props;
+  const { options = defaultCategory, placeHolder = '카테고리 선택' } = props;
   const [isOpen, setIsOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState(placeHolder);
 
   // 버튼 이벤트
   const toggleDropdown = () => {
     setIsOpen(!isOpen);
+  };
+
+  const onSelect = (option: string) => {
+    setSelectedItem(option);
+    setIsOpen(false);
   };
 
   return (
@@ -50,9 +55,7 @@ const CategorySelector = (props: CategorySelectorProps) => {
         </button>
       </div>
 
-      {isOpen && (
-        <DropdownList options={category} onSelect={setSelectedItem} onClose={toggleDropdown} />
-      )}
+      {isOpen && <DropdownList options={options} onSelect={onSelect} />}
     </div>
   );
 };

--- a/app/_styled-guide/_components/SortSelector.tsx
+++ b/app/_styled-guide/_components/SortSelector.tsx
@@ -4,21 +4,25 @@ import { useState } from 'react';
 import { IoMdArrowDropdown } from 'react-icons/io';
 import DropdownList from './DropdownList';
 
-interface CategorySelectorProps {
-  category?: string[];
+interface SortSelectorProps {
+  options?: string[];
   placeHolder?: string;
 }
 
 // sort 기능을 위한 드롭다운 메뉴 컴포넌트입니다.
-const SortSelector = (props: CategorySelectorProps) => {
-  const options = ['최신순', '별점 높은순', '별점 낮은순', '좋아요순'];
-  const { category = options, placeHolder = '최신순' } = props;
+const SortSelector = (props: SortSelectorProps) => {
+  const defaultOptions = ['최신순', '별점 높은순', '별점 낮은순', '좋아요순'];
+  const { options = defaultOptions, placeHolder = '최신순' } = props;
   const [isOpen, setIsOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState(placeHolder);
 
-  // 버튼 이벤트
   const toggleDropdown = () => {
     setIsOpen(!isOpen);
+  };
+
+  const onSelect = (option: string) => {
+    setSelectedItem(option);
+    setIsOpen(false);
   };
 
   return (
@@ -38,9 +42,8 @@ const SortSelector = (props: CategorySelectorProps) => {
         </button>
         {isOpen && (
           <DropdownList
-            options={category}
-            onSelect={setSelectedItem}
-            onClose={toggleDropdown}
+            options={options}
+            onSelect={onSelect}
             className="absolute mt-2 w-[108px] md:w-[140px] lg:w-40 lg:text-base text-gray-600 rounded-lg"
             optionClassName="px-1 md:px-3 lg:px-5 text-sm md:text-base"
           />

--- a/app/_styled-guide/_components/compare-page-input.tsx
+++ b/app/_styled-guide/_components/compare-page-input.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useState } from 'react';
 import SuggestiveSearchInput from './suggestive-search-input';
-
 import CompareTag from '@/components/ui/tags/CompareTag';
 import { SET_PRODUCT } from '@/constants/messages';
 
@@ -13,26 +12,26 @@ function ComparePageInput() {
     setKeyword('');
     setTag(option);
   };
+
   const onTagDelete = () => {
     setTag('');
   };
 
   return (
-    <div className="w-[300px] relative">
-      <div className="flex items-center bg-black-400 py-2 px-3 rounded">
-        {tag && <CompareTag productName={tag} onDelete={onTagDelete} />}
-        <div className="flex-1">
-          <SuggestiveSearchInput
-            onSelect={onSelect}
-            keyword={keyword}
-            setKeyword={setKeyword}
-            placeholder={tag ? '' : SET_PRODUCT}
-            boxClassName="bg-transparent"
-            inputClassName="w-full"
-            onDisabled={!!tag} // 태그가 있을 때 입력을 비활성화하기 위한 prop 추가
-          />
+    <div className="relative flex items-center w-full lg:w-[350px] h-[55px] lg:h-[70px] bg-black-400 rounded-lg">
+      {tag && (
+        <div className="flex-shrink-0 px-5">
+          <CompareTag productName={tag} onDelete={onTagDelete} />
         </div>
-      </div>
+      )}
+      <SuggestiveSearchInput
+        onSelect={onSelect}
+        keyword={keyword}
+        setKeyword={setKeyword}
+        placeholder={tag ? '' : SET_PRODUCT}
+        inputClassName="w-full bg-transparent text-white"
+        onDisabled={!!tag}
+      />
     </div>
   );
 }

--- a/app/_styled-guide/_components/compare-page-input.tsx
+++ b/app/_styled-guide/_components/compare-page-input.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { useState } from 'react';
+import SuggestiveSearchInput from './suggestive-search-input';
+
+import CompareTag from '@/components/ui/tags/CompareTag';
+import { SET_PRODUCT } from '@/constants/messages';
+
+function ComparePageInput() {
+  const [keyword, setKeyword] = useState<string>('');
+  const [tag, setTag] = useState<string>('');
+
+  const onSelect = (option: string) => {
+    setKeyword('');
+    setTag(option);
+  };
+  const onTagDelete = () => {
+    setTag('');
+  };
+
+  return (
+    <div className="w-[300px] relative">
+      <div className="flex items-center bg-black-400 py-2 px-3 rounded">
+        {tag && <CompareTag productName={tag} onDelete={onTagDelete} />}
+        <div className="flex-1">
+          <SuggestiveSearchInput
+            onSelect={onSelect}
+            keyword={keyword}
+            setKeyword={setKeyword}
+            placeholder={tag ? '' : SET_PRODUCT}
+            boxClassName="bg-transparent"
+            inputClassName="w-full"
+            onDisabled={!!tag} // 태그가 있을 때 입력을 비활성화하기 위한 prop 추가
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ComparePageInput;

--- a/app/_styled-guide/_components/gnb-search-bar.tsx
+++ b/app/_styled-guide/_components/gnb-search-bar.tsx
@@ -5,6 +5,7 @@ import React, { useState, useRef } from 'react';
 import useSearchSuggestions from '@/hooks/useSearchSuggestions';
 import DropdownList from './DropdownList';
 import { useRouter } from 'next/navigation';
+import useDropdown from '@/hooks/useDropdown';
 
 interface SearchBarProps {
   placeholder?: string;
@@ -14,23 +15,8 @@ interface SearchBarProps {
 const GnbSearchBar = ({ placeholder = '상품 이름을 검색해 보세요' }: SearchBarProps) => {
   const [keyword, setKeyword] = useState('');
   const { suggestions, isLoading, isError } = useSearchSuggestions(keyword);
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const { inputRef, isDropdownOpen, handleFocus, handleBlur } = useDropdown();
   const router = useRouter();
-
-  // 검색창 input 활성화시, dropdownList 열림
-  const handleFocus = () => {
-    setIsDropdownOpen(true);
-  };
-
-  const handleBlur = () => {
-    // input 요소가 focus를 잃어도 0.2초동안 Dropdown을 유지합니다.
-    setTimeout(() => {
-      if (!inputRef.current?.contains(document.activeElement)) {
-        setIsDropdownOpen(false);
-      }
-    }, 200);
-  };
 
   // 검색 처리 함수. 한 글자 이상 입력해야 함
   const executeSearch = () => {

--- a/app/_styled-guide/_components/suggestive-search-input.tsx
+++ b/app/_styled-guide/_components/suggestive-search-input.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import React, { useState, useRef } from 'react';
+import { IoMdArrowDropdown } from 'react-icons/io';
+import useSearchSuggestions from '@/hooks/useSearchSuggestions';
+import DropdownList from './DropdownList';
+
+interface SuggestiveSearchInputProps {
+  keyword: string;
+  setKeyword: (keyword: string) => void;
+  onSelect: (option: string) => void;
+  onEnter?: (keyword: string) => void;
+  placeholder?: string;
+  boxClassName?: string;
+  inputClassName?: string;
+}
+
+/**
+ * 검색어를 포함하는 상품명들을 드롭다운으로 보여주는 인풋창입니다. 입력값이 유효한 상품명인지 알 수 없기 때문에 onSubmit과 onSelect를 분리했습니다.
+ *
+ * @param {Object} props - SearchInputProps
+ * @param {string} props.keyword - 인풋의 값 (상위 컴포넌트의 state).
+ * @param {function} props.setKeyword - 인풋 변경 함수 (상위 컴포넌트의 setState).
+ * @param {function} props.onSelect - Dropdown에서 선택지를 골랐을 때의 동작.
+ * @param {function} [props.onEnter] - 인풋 창에서 내용을 입력한 뒤 엔터키를 눌렀을 때 동작.
+ * @param {string} [props.placeholder='상품 이름을 검색해 보세요'] - 인풋창이 비어있을 때 보여질 내용.
+ * @param {string} [props.boxClassName] - 인풋 박스의 Tailwind CSS 클래스 이름.
+ * @param {string} [props.inputClassName] - 인풋 내용의 Tailwind CSS 클래스 이름.
+ */
+const SuggestiveSearchInput = ({
+  keyword = '',
+  setKeyword,
+  onSelect,
+  onEnter,
+  placeholder = '상품 이름을 검색해 보세요',
+  boxClassName,
+  inputClassName,
+}: SuggestiveSearchInputProps) => {
+  const { suggestions, isLoading, isError } = useSearchSuggestions(keyword);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // 검색창 input 활성화시, dropdownList 열림
+  const handleFocus = () => {
+    setIsDropdownOpen(true);
+  };
+
+  const handleBlur = () => {
+    // input 요소가 focus를 잃어도 0.2초동안 Dropdown을 유지합니다.
+    setTimeout(() => {
+      if (!inputRef.current?.contains(document.activeElement)) {
+        setIsDropdownOpen(false);
+      }
+    }, 200);
+  };
+
+  // 검색창에서 엔터 입력 시 동작. 검색어는 한 글자 이상 입력해야 함
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && keyword.trim() && onEnter) {
+      onEnter(keyword);
+    }
+  };
+
+  return (
+    <div className="relative">
+      <div className={`flex justify-between items-center py-4 px-5 ${boxClassName}`}>
+        <input
+          ref={inputRef}
+          type="text"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className={`w-full bg-transparent focus:outline-none text-white ${inputClassName}`}
+        />
+        <button onClick={() => inputRef.current?.focus()}>
+          {!isDropdownOpen && <IoMdArrowDropdown />}
+        </button>
+      </div>
+
+      {isDropdownOpen && <DropdownList options={suggestions} onSelect={onSelect} />}
+    </div>
+  );
+};
+
+export default SuggestiveSearchInput;

--- a/app/_styled-guide/_components/suggestive-search-input.tsx
+++ b/app/_styled-guide/_components/suggestive-search-input.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useRef } from 'react';
+import React from 'react';
 import { IoMdArrowDropdown } from 'react-icons/io';
 import useSearchSuggestions from '@/hooks/useSearchSuggestions';
 import DropdownList from './DropdownList';
@@ -51,8 +51,8 @@ const SuggestiveSearchInput = ({
   };
 
   return (
-    <div className="relative">
-      <div className={`flex justify-between items-center py-4 px-5 ${boxClassName}`}>
+    <div className="relative flex-1">
+      <div className={`flex justify-between items-center px-5 ${boxClassName}`}>
         <input
           ref={inputRef}
           type="text"
@@ -62,15 +62,16 @@ const SuggestiveSearchInput = ({
           onBlur={handleBlur}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className={`w-full bg-transparent focus:outline-none text-white ${inputClassName}`}
-          disabled={onDisabled} // 태그가 있을 때 인풋 비활성화
+          className={`w-full focus:outline-none ${inputClassName}`}
+          disabled={onDisabled}
         />
         <button onClick={() => inputRef.current?.focus()}>
           {!isDropdownOpen && <IoMdArrowDropdown />}
         </button>
       </div>
-
-      {isDropdownOpen && <DropdownList options={suggestions} onSelect={onSelect} />}
+      {isDropdownOpen && (
+        <DropdownList options={suggestions} onSelect={onSelect} className="mt-7" />
+      )}
     </div>
   );
 };

--- a/app/_styled-guide/_components/suggestive-search-input.tsx
+++ b/app/_styled-guide/_components/suggestive-search-input.tsx
@@ -4,8 +4,9 @@ import React, { useState, useRef } from 'react';
 import { IoMdArrowDropdown } from 'react-icons/io';
 import useSearchSuggestions from '@/hooks/useSearchSuggestions';
 import DropdownList from './DropdownList';
+import useDropdown from '@/hooks/useDropdown';
 
-interface SuggestiveSearchInputProps {
+export interface SuggestiveSearchInputProps {
   keyword: string;
   setKeyword: (keyword: string) => void;
   onSelect: (option: string) => void;
@@ -13,6 +14,7 @@ interface SuggestiveSearchInputProps {
   placeholder?: string;
   boxClassName?: string;
   inputClassName?: string;
+  onDisabled?: boolean;
 }
 
 /**
@@ -37,22 +39,7 @@ const SuggestiveSearchInput = ({
   inputClassName,
 }: SuggestiveSearchInputProps) => {
   const { suggestions, isLoading, isError } = useSearchSuggestions(keyword);
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  // 검색창 input 활성화시, dropdownList 열림
-  const handleFocus = () => {
-    setIsDropdownOpen(true);
-  };
-
-  const handleBlur = () => {
-    // input 요소가 focus를 잃어도 0.2초동안 Dropdown을 유지합니다.
-    setTimeout(() => {
-      if (!inputRef.current?.contains(document.activeElement)) {
-        setIsDropdownOpen(false);
-      }
-    }, 200);
-  };
+  const { inputRef, isDropdownOpen, handleFocus, handleBlur } = useDropdown();
 
   // 검색창에서 엔터 입력 시 동작. 검색어는 한 글자 이상 입력해야 함
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/app/_styled-guide/_components/suggestive-search-input.tsx
+++ b/app/_styled-guide/_components/suggestive-search-input.tsx
@@ -28,6 +28,7 @@ export interface SuggestiveSearchInputProps {
  * @param {string} [props.placeholder='상품 이름을 검색해 보세요'] - 인풋창이 비어있을 때 보여질 내용.
  * @param {string} [props.boxClassName] - 인풋 박스의 Tailwind CSS 클래스 이름.
  * @param {string} [props.inputClassName] - 인풋 내용의 Tailwind CSS 클래스 이름.
+ * @param {boolean} props.isTagPresent - 태그가 있을 때 인풋을 비활성화하기 위한 prop.
  */
 const SuggestiveSearchInput = ({
   keyword = '',
@@ -37,6 +38,7 @@ const SuggestiveSearchInput = ({
   placeholder = '상품 이름을 검색해 보세요',
   boxClassName,
   inputClassName,
+  onDisabled,
 }: SuggestiveSearchInputProps) => {
   const { suggestions, isLoading, isError } = useSearchSuggestions(keyword);
   const { inputRef, isDropdownOpen, handleFocus, handleBlur } = useDropdown();
@@ -61,6 +63,7 @@ const SuggestiveSearchInput = ({
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           className={`w-full bg-transparent focus:outline-none text-white ${inputClassName}`}
+          disabled={onDisabled} // 태그가 있을 때 인풋 비활성화
         />
         <button onClick={() => inputRef.current?.focus()}>
           {!isDropdownOpen && <IoMdArrowDropdown />}

--- a/constants/messages.ts
+++ b/constants/messages.ts
@@ -1,2 +1,3 @@
 export const NO_RESULT: string = '검색 결과가 없습니다.';
 export const NO_KEYWORD: string = '검색어를 입력해주세요';
+export const SET_PRODUCT: string = '상품을 등록해 주세요';

--- a/hooks/useDropdown.ts
+++ b/hooks/useDropdown.ts
@@ -1,0 +1,32 @@
+import { useState, useRef } from 'react';
+
+// input 요소에 드롭다운형 목록을 보여줄 때 사용하는 커스텀 훅입니다.
+// inputRef는 포커스를 관리하기 위해서 사용합니다.
+const useDropdown = () => {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // 검색창 input 활성화시, dropdownList 열림
+  const handleFocus = () => {
+    setIsDropdownOpen(true);
+  };
+
+  // input 요소가 focus를 잃어도 설정한 시간 동안 Dropdown을 유지합니다.
+  const handleBlur = () => {
+    setTimeout(() => {
+      if (!inputRef.current?.contains(document.activeElement)) {
+        setIsDropdownOpen(false);
+      }
+    }, 100);
+  };
+
+  return {
+    inputRef,
+    isDropdownOpen,
+    setIsDropdownOpen,
+    handleFocus,
+    handleBlur,
+  };
+};
+
+export default useDropdown;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a2341355-ffb3-4d12-b8a9-b7f7d3cbc86b)

-  dropdown-list 변경사항
onClose를 따로 prop으로 전달하지 않고 isOpen 상태를 상위에서 관리하도록 수정했습니다.
해당 부분 category-selector와 sort-selector에 적용되었고 추가로 props명을 좀 더 직관적으로 수정하였습니다.

- SuggestiveSearchInput 컴포넌트
입력한 상품명을 검색해 드롭다운에 검색결과를 보여주고, 선택할 수 있는 컴포넌트입니다.
선택지 클릭 시 동작과 엔터키 동작을 분리했습니다. onSelect는 필수지만 onEnter는 추가하지 않아도 됩니다.
전에 입력한 내용을 기억해 검색어가 비었을 때 표시하게 해도 좋을 것 같습니다.

- useDropdown 훅
dropdown을 사용하는 부분에서 공통적으로 작성되는 부분을 묶어 훅으로 만들었습니다.
드롭다운을 열고 닫기 위한 state인 isDropdownOpen, setIsDropdownOpen이 있고, 인풋이 포커스 되거나 풀릴 때 드롭다운을 열고 닫는 동작을 하는 handleFocus, handleBlur 함수가 있습니다.
inputRef는 인풋 창 포커스 상태를 변경하는데에 사용합니다. 사용하는 input에 ref={inputRef}를 걸어 포커스 관련 동작을 작성할 때 사용합니다.
컴포넌트인 SortSelector와 CategorySelector 부분에서 해당 훅을 사용하게 코드 수정했습니다.

- ComparePageInput 컴포넌트
상품명을 선택하면 태그모양으로 넣을 수 있게 작동해야되서 컴포넌트화해서 따로 개발했습니다.
모달에서 사용할 컴포넌트는 추가로 작성 예정입니다.