### PR TITLE
[모달 3종 기능 수정] 상품 추가 모달 유효성 수정

### DIFF
--- a/app/_styled-guide/_components/CategorySelector.tsx
+++ b/app/_styled-guide/_components/CategorySelector.tsx
@@ -15,6 +15,7 @@ interface CategorySelectorProps {
 
   placeHolder?: string;
   onChange?: (value: CategoryOption) => void;
+  onSelectOption?: () => void;
 }
 
 // 카테고리 선택 기능을 위한 드롭다운 메뉴 컴포넌트입니다.
@@ -35,6 +36,7 @@ const CategorySelector = ({
   ],
   placeHolder = '카테고리 선택',
   onChange,
+  onSelectOption,
 }: CategorySelectorProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<CategoryOption | undefined>(initialValue);
@@ -49,6 +51,7 @@ const CategorySelector = ({
     if (onChange) {
       onChange(option);
     }
+    if (onSelectOption) onSelectOption();
   };
 
   return (

--- a/app/_styled-guide/_components/add-product-modal.tsx
+++ b/app/_styled-guide/_components/add-product-modal.tsx
@@ -310,7 +310,7 @@ export default function AddProductModal({ triggerButton }: AddProductModalProps)
               type="button"
               variant="default"
               onClick={form.handleSubmit(onSubmit)}
-              disabled={!form.formState.isValid || isSaving}
+              disabled={isSaving}
             >
               {isSaving ? '저장 중..' : '추가하기'}
             </Button>

--- a/app/_styled-guide/_components/add-product-modal.tsx
+++ b/app/_styled-guide/_components/add-product-modal.tsx
@@ -27,7 +27,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useUploadImage } from '@/hooks/image';
 import { useCreateProduct } from '@/hooks/product';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { toast } from 'sonner';
 import { z } from 'zod';
 import { useDataQuery } from '@/services/common';
@@ -35,19 +35,17 @@ import { ProductsListResponse } from '@/types/data';
 import { useRouter } from 'next/navigation';
 import { BiImageAdd } from 'react-icons/bi';
 import { renameFileWithExtension } from '@/utils/textUtils';
+import useDebounce from '@/hooks/useDebounce';
 
 const FormSchema = z.object({
   name: z
-    .string()
-    .min(1, '상품명을 입력해 주세요')
-    .max(20, '상품명은 최대 20자까지 입력 가능합니다.'),
-  categoryName: z.string().min(1, '카테고리를 선택해 주세요'),
+    .string({ message: '상품 이름은 필수 입력입니다.' })
+    .max(20, { message: '상품명은 최대 20자까지 입력 가능합니다.' }),
+  categoryName: z.string({ message: '카테고리를 선택해주세요.' }),
   desc: z
-    .string()
-    .min(1, { message: '상품 설명은 필수 입력입니다.' })
-    .min(10, { message: '최소 10자 이상 적어주세요.' })
-    .max(500, '상품 설명은 최대 500자까지 입력 가능합니다.'),
-  image: z.string().min(1, '이미지를 업로드해 주세요'),
+    .string({ message: '상품 설명은 필수 입력입니다.' })
+    .min(10, { message: '최소 10자 이상 적어주세요.' }),
+  image: z.string({ message: '이미지를 업로드해 주세요' }),
   categoryId: z.number(),
 });
 
@@ -75,6 +73,8 @@ function isServerError(error: unknown): error is { response: { data: ServerError
 export default function AddProductModal({ triggerButton }: AddProductModalProps) {
   const [imageUrl, setImageUrl] = useState<string>('');
   const [descLength, setDescLength] = useState(0);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
   const router = useRouter();
 
   const uploadImageMutation = useUploadImage();
@@ -82,26 +82,44 @@ export default function AddProductModal({ triggerButton }: AddProductModalProps)
 
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
-    mode: 'onChange',
+    mode: 'onBlur',
   });
 
+  const watchedName = useDebounce(
+    useWatch({
+      control: form.control,
+      name: 'name',
+      defaultValue: '', // Provide a default value to avoid undefined
+    }),
+    100,
+  );
   // 상품명 중복 체크
-  const {
-    data,
-    isLoading: queryLoading,
-    isError: queryError,
-  } = useDataQuery<undefined, ProductsListResponse>(
-    ['products', 'searchSuggestions', form.getValues('name')],
+  const { data } = useDataQuery<undefined, ProductsListResponse>(
+    ['products', 'searchSuggestions', watchedName],
     '/products',
     undefined,
-    {
-      staleTime: 60 * 1000,
-    },
-    { keyword: form.getValues('name') },
+    { enabled: !!watchedName },
+    { keyword: watchedName },
   );
   function isProductNameDuplicate(name: string): boolean {
     return data ? data.list.some((product: { name: string }) => product.name === name) : false;
   }
+
+  const handleNameBlur = async () => {
+    if (watchedName) {
+      const isDuplicate = isProductNameDuplicate(watchedName);
+      if (isDuplicate) {
+        form.setError('name', { type: 'manual', message: '이미 등록된 상품명입니다.' });
+        return;
+      } else {
+        form.clearErrors('name'); // 중복이 아니고 값이 있음
+        return;
+      }
+    } else {
+      form.setError('name', { type: 'manual', message: '상품 이름은 필수 입력입니다.' });
+      return;
+    }
+  };
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -112,6 +130,7 @@ export default function AddProductModal({ triggerButton }: AddProductModalProps)
         const response = await uploadImageMutation.mutateAsync(formData);
         setImageUrl(response.url);
         form.setValue('image', response.url);
+        form.clearErrors('image');
       } catch (error) {
         toast.error('이미지 업로드 중 오류가 발생했습니다.');
       }
@@ -120,11 +139,19 @@ export default function AddProductModal({ triggerButton }: AddProductModalProps)
 
   const onSubmit = async (formData: z.infer<typeof FormSchema>) => {
     try {
+      setIsSaving(true);
       const { name, desc, image, categoryId } = formData;
+
       const updatedData = { name, description: desc, image, categoryId };
       const response = await createProduct.mutateAsync(updatedData);
       toast.success('상품이 성공적으로 업데이트되었습니다.');
       router.push(`/product/${response.id}`); // 상품 상세 페이지로 이동
+
+      // 폼 리셋
+      form.reset();
+      setImageUrl('');
+      setDescLength(0);
+      setIsOpen(false);
     } catch (error) {
       if (isServerError(error)) {
         const errorData = error.response.data;
@@ -142,21 +169,13 @@ export default function AddProductModal({ triggerButton }: AddProductModalProps)
 
         toast.error(errorMessage);
       }
-    }
-  };
-
-  const handleNameBlur = async () => {
-    const name = form.getValues('name');
-    if (name) {
-      const isDuplicate = isProductNameDuplicate(name);
-      if (isDuplicate) {
-        form.setError('name', { type: 'manual', message: '이미 등록된 상품명입니다.' });
-      }
+    } finally {
+      setIsSaving(false);
     }
   };
 
   return (
-    <Dialog>
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>{triggerButton}</DialogTrigger>
       <DialogContent className="max-w-[660px]">
         <DialogHeader>
@@ -233,9 +252,20 @@ export default function AddProductModal({ triggerButton }: AddProductModalProps)
                     <FormItem>
                       <FormControl>
                         <CategorySelector
+                          initialValue={
+                            form.getValues('categoryName')
+                              ? {
+                                  name: form.getValues('categoryName'),
+                                  id: form.getValues('categoryId'),
+                                }
+                              : undefined
+                          }
                           onChange={(value) => {
                             form.setValue('categoryId', value.id);
                             form.setValue('categoryName', value.name);
+                          }}
+                          onSelectOption={() => {
+                            form.clearErrors('categoryName');
                           }}
                         />
                       </FormControl>
@@ -254,9 +284,10 @@ export default function AddProductModal({ triggerButton }: AddProductModalProps)
                   <div className="relative">
                     <FormControl>
                       <Textarea
+                        {...field}
                         placeholder="상품 설명을 입력해 주세요"
                         className="h-[120px] smd:h-[160px]"
-                        {...field}
+                        maxLength={500}
                         onChange={(e) => {
                           field.onChange(e);
                           setDescLength(e.target.value.length);
@@ -275,8 +306,13 @@ export default function AddProductModal({ triggerButton }: AddProductModalProps)
         </Form>
         <DialogFooter className="sm:justify-start">
           <DialogClose asChild>
-            <Button type="button" variant="default" onClick={form.handleSubmit(onSubmit)}>
-              추가하기
+            <Button
+              type="button"
+              variant="default"
+              onClick={form.handleSubmit(onSubmit)}
+              disabled={!form.formState.isValid || isSaving}
+            >
+              {isSaving ? '저장 중..' : '추가하기'}
             </Button>
           </DialogClose>
         </DialogFooter>

--- a/app/_styled-guide/_components/add-product-modal.tsx
+++ b/app/_styled-guide/_components/add-product-modal.tsx
@@ -207,9 +207,7 @@ export default function AddProductModal({ triggerButton }: AddProductModalProps)
                             htmlFor="productPicture"
                             variant="file"
                             style={{
-                              backgroundImage: imageUrl
-                                ? `url(${imageUrl})`
-                                : `url(${field.value})`,
+                              backgroundImage: imageUrl ? `url(${imageUrl})` : field.value,
                             }}
                           >
                             {!imageUrl && (

--- a/components/modal/profile.tsx
+++ b/components/modal/profile.tsx
@@ -25,14 +25,15 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { ImFilePicture } from 'react-icons/im';
-import { IoCloseSharp } from 'react-icons/io5';
 import { toast } from 'sonner';
 import { z } from 'zod';
 import { Input } from '../ui/input';
 import { renameFileWithExtension } from '@/utils/textUtils';
 
 const FormSchema = z.object({
-  nickname: z.string().min(1, { message: '이름은 필수 입력입니다.' }),
+  nickname: z
+    .string({ message: '이름은 필수 입력입니다.' })
+    .max(10, { message: '이름은 최대 10자까지 입력 가능합니다.' }),
   description: z.string(),
   image: z.string().nullable(),
 });


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/d87ca001-61a0-469b-8238-91e2fea09f8c)

상품명 중복 관련 로직 수정, useWatch로 name을 추적하게 바뀜.
상품추가 폼 제출 이후 모달을 닫고, 폼을 리셋하도록 변경.

현재 위 이미지처럼 이미지 없을 때의 메세지가 인풋에 가리고있음.


