### PR TITLE
[스타일 수정] 이미지 폼 메세지가 인풋에 가리던 현상 수정

### DIFF
--- a/app/_styled-guide/_components/CategorySelector.tsx
+++ b/app/_styled-guide/_components/CategorySelector.tsx
@@ -40,6 +40,7 @@ const CategorySelector = ({
 }: CategorySelectorProps) => {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedItem, setSelectedItem] = useState<CategoryOption | undefined>(initialValue);
+
   // 버튼 이벤트
   const toggleDropdown = () => {
     setIsOpen(!isOpen);
@@ -55,11 +56,11 @@ const CategorySelector = ({
   };
 
   return (
-    <div className="relative inline-block text-left w-full">
+    <div className="relative inline-block text-left w-full ">
       <div>
         <button
           type="button"
-          className="inline-flex justify-between align-middle w-full rounded-lg border-gray-700 hover:border-blue bg-black-450 px-5 py-[1.063rem] lg:py-[1.438rem] text-sm font-medium text-gray-600 hover:text-white"
+          className="inline-flex justify-between items-center align-middle w-full rounded-lg border-gray-650 border hover:border-blue bg-black-450 px-5 h-[53px] md:h-[68px] text-sm md:text-base font-medium text-gray-600 hover:text-white"
           aria-expanded="true"
           aria-haspopup="true"
           onClick={toggleDropdown}

--- a/app/_styled-guide/_components/add-product-modal.tsx
+++ b/app/_styled-guide/_components/add-product-modal.tsx
@@ -194,8 +194,8 @@ export default function AddProductModal({ triggerButton }: AddProductModalProps)
                 name="image"
                 render={({ field }) => (
                   <FormItem>
-                    <div className="relative flex h-[140px] md:h-full w-[140px] md:w-[135px] lg:w-[160px]">
-                      <FormControl>
+                    <div className="relative flex h-[152px] w-[140px] md:w-[160px] lg:w-[160px]">
+                      <FormControl className="flex-grow-0">
                         <>
                           <Input
                             id="productPicture"


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/97b4bceb-4192-42da-9f03-9b2c92165543)

+ 폼 메세지가 인풋에 가리던 현상 수정
+ categorySelector가 반응형에 의해 디자인이 어색한 부분 수정